### PR TITLE
Fix Drizzle ORM type errors and harden class queries

### DIFF
--- a/backend/src/db/index.ts
+++ b/backend/src/db/index.ts
@@ -1,6 +1,13 @@
 import { drizzle } from 'drizzle-orm/postgres-js'
 import postgres from 'postgres'
 
-const connectionString = process.env.MAIN_DATABASE_URL || process.env.DATABASE_URL || 'postgresql://school_management:ecole_management%232025@localhost:5432/school_management'
+const connectionString = process.env.MAIN_DATABASE_URL || process.env.DATABASE_URL
+
+if (!connectionString) {
+  throw new Error(
+    'Database connection string is not configured. Set MAIN_DATABASE_URL or DATABASE_URL in the environment before starting the server.'
+  )
+}
+
 const client = postgres(connectionString)
 export const db = drizzle(client)

--- a/backend/src/lib/refresh-token.ts
+++ b/backend/src/lib/refresh-token.ts
@@ -1,5 +1,5 @@
 import crypto from 'crypto'
-import { eq, and, lt } from 'drizzle-orm'
+import { eq, and, lt, gt } from 'drizzle-orm'
 import { db } from '../db'
 import { refreshTokens, users, type RefreshToken, type NewRefreshToken } from '../db/schema'
 
@@ -74,7 +74,7 @@ export const verifyRefreshToken = async (
       and(
         eq(refreshTokens.tokenHash, tokenHash),
         eq(refreshTokens.isRevoked, false),
-        lt(new Date(), refreshTokens.expiresAt) // Not expired
+        gt(refreshTokens.expiresAt, new Date()) // Not expired
       )
     )
     .limit(1)
@@ -217,7 +217,7 @@ export const getUserActiveTokens = async (userId: string): Promise<RefreshToken[
       and(
         eq(refreshTokens.userId, userId),
         eq(refreshTokens.isRevoked, false),
-        lt(new Date(), refreshTokens.expiresAt)
+        gt(refreshTokens.expiresAt, new Date())
       )
     )
     .orderBy(refreshTokens.lastUsedAt)


### PR DESCRIPTION
## Summary
- protect the registration endpoint with authentication and role guards to prevent self-service account creation
- ensure school administrators can only create users for their own school and cannot elevate accounts to super admin
- require explicit database connection strings instead of falling back to embedded credentials
- resolve Drizzle ORM type errors by correcting refresh token comparisons, normalising decimal point values, and restructuring filtered queries
- ensure class pagination counts join teacher records so search filters do not break aggregate queries
- remove verbose user creation request logging that exposed raw payloads in production

## Testing
- bun run typecheck
- bun run build

------
https://chatgpt.com/codex/tasks/task_e_68de05b0239c832384da2433a29b5c9b