### PR TITLE
Add document upload pipeline

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -13,3 +13,22 @@ bun run index.ts
 ```
 
 This project was created using `bun init` in bun v1.2.20. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.
+
+## Document uploads
+
+The document pipeline streams uploads directly to Amazon S3. Configure the following
+environment variables before running the server:
+
+| Variable | Description |
+| --- | --- |
+| `AWS_REGION` | AWS region where the bucket resides. |
+| `AWS_S3_BUCKET` | Target bucket for stored documents. |
+| `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` | Credentials used when an instance profile is not available. |
+| `AWS_S3_ENDPOINT` | *(Optional)* Custom endpoint (useful for S3-compatible stores such as MinIO). |
+| `AWS_S3_FORCE_PATH_STYLE` | *(Optional)* Set to `true` when path-style addressing is required. |
+| `DOCUMENT_ALLOWED_MIME_TYPES` | *(Optional)* Comma-separated list of accepted MIME types. Defaults to common document formats. |
+| `DOCUMENT_MAX_BYTES` | *(Optional)* Maximum upload size in bytes (defaults to 5MB to align with API limits). |
+
+The `/api/documents` endpoints expect `multipart/form-data` submissions with the file
+attached under the `file` field. Metadata and tag payloads can be provided as JSON strings
+in the `metadata` and `tags` fields respectively.

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -10,6 +10,7 @@ import usersRoutes from './src/routes/users'
 import classesRoutes from './src/routes/classes'
 import assignmentsRoutes from './src/routes/assignments'
 import gradesRoutes from './src/routes/grades'
+import documentsRoutes from './src/routes/documents'
 
 import { 
   rateLimit, 
@@ -157,6 +158,7 @@ app.route('/api/users', usersRoutes)
 app.route('/api/classes', classesRoutes)
 app.route('/api/assignments', assignmentsRoutes)
 app.route('/api/grades', gradesRoutes)
+app.route('/api/documents', documentsRoutes)
 
 // Global error handler
 app.onError((err, c) => {

--- a/backend/package.json
+++ b/backend/package.json
@@ -30,6 +30,8 @@
     "typescript": "^5.3.0"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.600.0",
+    "@aws-sdk/lib-storage": "^3.600.0",
     "@hono/node-server": "^1.19.0",
     "@hono/zod-validator": "^0.7.2",
     "@types/bcryptjs": "^3.0.0",

--- a/backend/src/lib/document-processor.ts
+++ b/backend/src/lib/document-processor.ts
@@ -133,7 +133,7 @@ class DocumentProcessor {
   }
 
   private createChecksum(buffer: Buffer) {
-    return createHash('sha256').update(buffer).digest('hex')
+    return createHash('sha256').update(buffer).digest('base64')
   }
 
   public async upload(input: DocumentUploadInput): Promise<DocumentUploadResult> {

--- a/backend/src/lib/document-processor.ts
+++ b/backend/src/lib/document-processor.ts
@@ -1,0 +1,191 @@
+import { createHash, randomUUID } from 'node:crypto'
+import type { Buffer } from 'node:buffer'
+
+import { db } from '../db'
+import { documents } from '../db/schema'
+import type { Document } from '../db/schema'
+import { uploadBufferToS3, normalizeS3Metadata } from './s3-client'
+
+const DEFAULT_ALLOWED_TYPES = new Set([
+  'application/pdf',
+  'image/png',
+  'image/jpeg',
+  'text/plain',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+])
+
+const DEFAULT_MAX_BYTES = 5 * 1024 * 1024 // 5MB
+
+export interface DocumentUploadInput {
+  buffer: Buffer
+  originalName: string
+  contentType?: string | null
+  uploaderId: string
+  schoolId: string
+  title?: string | null
+  description?: string | null
+  metadata?: Record<string, string | number | boolean | null | undefined>
+  tags?: Record<string, string>
+}
+
+export interface DocumentUploadResult {
+  document: Document
+  location?: string
+}
+
+interface SanitizedFileInfo {
+  originalFileName: string
+  baseName: string
+  extension: string
+  sanitizedFileName: string
+}
+
+class DocumentProcessor {
+  private readonly allowedContentTypes: Set<string>
+  private readonly maxFileBytes: number
+
+  constructor() {
+    this.allowedContentTypes = this.resolveAllowedContentTypes()
+    this.maxFileBytes = this.resolveMaxBytes()
+  }
+
+  private resolveAllowedContentTypes(): Set<string> {
+    const raw = process.env.DOCUMENT_ALLOWED_MIME_TYPES
+    if (!raw) return new Set(DEFAULT_ALLOWED_TYPES)
+
+    const parsed = raw
+      .split(',')
+      .map((value) => value.trim().toLowerCase())
+      .filter((value) => value.length > 0)
+
+    return parsed.length ? new Set(parsed) : new Set(DEFAULT_ALLOWED_TYPES)
+  }
+
+  private resolveMaxBytes(): number {
+    const raw = process.env.DOCUMENT_MAX_BYTES
+    if (!raw) return DEFAULT_MAX_BYTES
+
+    const parsed = Number(raw)
+    if (Number.isNaN(parsed) || parsed <= 0) {
+      return DEFAULT_MAX_BYTES
+    }
+
+    return parsed
+  }
+
+  private sanitizeFileName(fileName: string): SanitizedFileInfo {
+    const trimmed = fileName.trim()
+    const lastDotIndex = trimmed.lastIndexOf('.')
+
+    const base = lastDotIndex > 0 ? trimmed.slice(0, lastDotIndex) : trimmed
+    const extension = lastDotIndex > 0 ? trimmed.slice(lastDotIndex + 1) : ''
+
+    const sanitizedBase = base
+      .toLowerCase()
+      .replace(/[^a-z0-9-_]/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-|-$/g, '') || 'document'
+
+    const sanitizedExtension = extension.toLowerCase().replace(/[^a-z0-9]/g, '')
+
+    const sanitizedFileName = sanitizedExtension
+      ? `${sanitizedBase}.${sanitizedExtension}`
+      : sanitizedBase
+
+    return {
+      originalFileName: trimmed,
+      baseName: sanitizedBase,
+      extension: sanitizedExtension,
+      sanitizedFileName,
+    }
+  }
+
+  private ensureFileSize(size: number) {
+    if (size <= 0) {
+      throw new Error('Document is empty')
+    }
+
+    if (size > this.maxFileBytes) {
+      throw new Error(`Document exceeds the maximum allowed size of ${this.maxFileBytes} bytes`)
+    }
+  }
+
+  private ensureContentType(contentType?: string | null) {
+    if (!contentType) return
+
+    const normalized = contentType.toLowerCase()
+    if (!this.allowedContentTypes.has(normalized)) {
+      throw new Error(`Content type ${contentType} is not allowed`)
+    }
+  }
+
+  private buildStorageKey(schoolId: string, sanitized: SanitizedFileInfo) {
+    const now = new Date()
+    const year = now.getUTCFullYear()
+    const month = String(now.getUTCMonth() + 1).padStart(2, '0')
+    const day = String(now.getUTCDate()).padStart(2, '0')
+
+    const uniquePart = randomUUID()
+    const extension = sanitized.extension ? `.${sanitized.extension}` : ''
+
+    return `documents/${schoolId}/${year}/${month}/${day}/${uniquePart}${extension}`
+  }
+
+  private createChecksum(buffer: Buffer) {
+    return createHash('sha256').update(buffer).digest('hex')
+  }
+
+  public async upload(input: DocumentUploadInput): Promise<DocumentUploadResult> {
+    const fileSize = input.buffer.byteLength
+    this.ensureFileSize(fileSize)
+    this.ensureContentType(input.contentType ?? undefined)
+
+    const sanitized = this.sanitizeFileName(input.originalName)
+    const checksum = this.createChecksum(input.buffer)
+    const storageKey = this.buildStorageKey(input.schoolId, sanitized)
+
+    const metadata = normalizeS3Metadata({
+      original_name: sanitized.originalFileName,
+      uploaded_by: input.uploaderId,
+      school_id: input.schoolId,
+      ...(input.metadata ?? {}),
+    })
+
+    const uploadResult = await uploadBufferToS3({
+      body: input.buffer,
+      key: storageKey,
+      contentType: input.contentType ?? undefined,
+      metadata: metadata,
+      checksum,
+      tags: input.tags,
+    })
+
+    const [documentRecord] = await db
+      .insert(documents)
+      .values({
+        schoolId: input.schoolId,
+        uploaderId: input.uploaderId,
+        title: input.title?.trim() || sanitized.baseName,
+        fileName: sanitized.sanitizedFileName,
+        contentType: input.contentType ?? null,
+        fileSize,
+        description: input.description?.trim() || null,
+        s3Bucket: uploadResult.bucket,
+        s3Key: uploadResult.key,
+        status: 'uploaded',
+        checksum,
+        metadata: metadata ? JSON.stringify(metadata) : null,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .returning()
+
+    return {
+      document: documentRecord,
+      location: uploadResult.location,
+    }
+  }
+}
+
+export const documentProcessor = new DocumentProcessor()

--- a/backend/src/lib/s3-client.ts
+++ b/backend/src/lib/s3-client.ts
@@ -1,0 +1,127 @@
+import { S3Client } from '@aws-sdk/client-s3'
+import { Upload } from '@aws-sdk/lib-storage'
+import type { Buffer } from 'node:buffer'
+
+let cachedClient: S3Client | null = null
+
+const resolveRegion = (): string => {
+  const region = process.env.AWS_REGION
+
+  if (!region) {
+    throw new Error('AWS_REGION environment variable is required for document uploads')
+  }
+
+  return region
+}
+
+const resolveBucket = (bucket?: string): string => {
+  const envBucket = bucket || process.env.AWS_S3_BUCKET || process.env.DOCUMENTS_S3_BUCKET
+
+  if (!envBucket) {
+    throw new Error('AWS_S3_BUCKET (or DOCUMENTS_S3_BUCKET) environment variable is required for document uploads')
+  }
+
+  return envBucket
+}
+
+export const getS3Client = (): S3Client => {
+  if (!cachedClient) {
+    const credentials = process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY
+      ? {
+          accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+          secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+        }
+      : undefined
+
+    cachedClient = new S3Client({
+      region: resolveRegion(),
+      endpoint: process.env.AWS_S3_ENDPOINT,
+      forcePathStyle: process.env.AWS_S3_FORCE_PATH_STYLE === 'true',
+      credentials,
+    })
+  }
+
+  return cachedClient
+}
+
+export interface UploadBufferOptions {
+  body: Buffer
+  key: string
+  bucket?: string
+  contentType?: string
+  metadata?: Record<string, string>
+  checksum?: string
+  tags?: Record<string, string>
+}
+
+const buildTaggingString = (tags?: Record<string, string>): string | undefined => {
+  if (!tags) return undefined
+
+  const entries = Object.entries(tags).filter(([, value]) => typeof value === 'string' && value.length > 0)
+  if (!entries.length) return undefined
+
+  return entries
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(value)}`)
+    .join('&')
+}
+
+export const normalizeS3Metadata = (
+  metadata?: Record<string, string | number | boolean | null | undefined>
+): Record<string, string> | undefined => {
+  if (!metadata) return undefined
+
+  const normalized: Record<string, string> = {}
+
+  for (const [rawKey, rawValue] of Object.entries(metadata)) {
+    if (rawValue === null || rawValue === undefined) continue
+
+    const key = rawKey
+      .toLowerCase()
+      .replace(/[^a-z0-9\-_.]/g, '_')
+      .slice(0, 128)
+
+    const value = String(rawValue).slice(0, 1024)
+
+    if (!key || !value) continue
+
+    normalized[key] = value
+  }
+
+  return Object.keys(normalized).length ? normalized : undefined
+}
+
+export interface UploadResult {
+  bucket: string
+  key: string
+  etag?: string
+  location?: string
+}
+
+export const uploadBufferToS3 = async (options: UploadBufferOptions): Promise<UploadResult> => {
+  const bucket = resolveBucket(options.bucket)
+  const client = getS3Client()
+  const metadata = normalizeS3Metadata(options.metadata)
+  const tagging = buildTaggingString(options.tags)
+
+  const upload = new Upload({
+    client,
+    params: {
+      Bucket: bucket,
+      Key: options.key,
+      Body: options.body,
+      ContentType: options.contentType,
+      Metadata: metadata,
+      ChecksumSHA256: options.checksum,
+      Tagging: tagging,
+    },
+  })
+
+  const result = await upload.done()
+
+  return {
+    bucket,
+    key: options.key,
+    etag: result.ETag,
+    location: `s3://${bucket}/${options.key}`,
+  }
+}

--- a/backend/src/routes/documents.test.ts
+++ b/backend/src/routes/documents.test.ts
@@ -1,0 +1,260 @@
+import { describe, expect, it } from 'bun:test'
+import { Hono } from 'hono'
+
+import { createDocumentsRouter } from './documents'
+import { documents } from '../db/schema'
+import type { DocumentUploadInput } from '../lib/document-processor'
+
+type DocumentRecord = typeof documents.$inferSelect
+
+type MockDb = {
+  select: (args?: unknown) => any
+}
+
+type TestUser = {
+  id: string
+  email: string
+  role: 'super_admin' | 'school_admin' | 'teacher'
+  schoolId?: string
+}
+
+const superAdminUser: TestUser = {
+  id: 'user-1',
+  email: 'admin@example.com',
+  role: 'super_admin',
+}
+
+const teacherUser: TestUser = {
+  id: 'user-2',
+  email: 'teacher@example.com',
+  role: 'teacher',
+  schoolId: 'school-123',
+}
+
+const createApp = (options: {
+  user: TestUser
+  db: MockDb
+  documentProcessor: { upload: (input: DocumentUploadInput) => Promise<{ document: DocumentRecord; location?: string }> }
+}) => {
+  const router = createDocumentsRouter({
+    authMiddleware: async (c, next) => {
+      c.set('user', options.user as any)
+      await next()
+    },
+    requireSchoolAccess: async (_c, next) => {
+      await next()
+    },
+    db: options.db as any,
+    documentProcessor: options.documentProcessor as any,
+  })
+
+  const app = new Hono()
+  app.route('/', router)
+  return app
+}
+
+describe('documents routes', () => {
+  it('lists documents with pagination metadata', async () => {
+    const now = new Date('2024-01-01T00:00:00.000Z')
+    const records: DocumentRecord[] = [
+      {
+        id: 'doc-1',
+        schoolId: 'school-001',
+        uploaderId: 'user-1',
+        title: 'Report 1',
+        fileName: 'report-1.pdf',
+        contentType: 'application/pdf',
+        fileSize: 1024,
+        description: 'First report',
+        s3Bucket: 'bucket',
+        s3Key: 'key-1',
+        status: 'uploaded',
+        checksum: 'abc',
+        metadata: JSON.stringify({ category: 'reports' }),
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        id: 'doc-2',
+        schoolId: 'school-001',
+        uploaderId: 'user-2',
+        title: 'Report 2',
+        fileName: 'report-2.pdf',
+        contentType: 'application/pdf',
+        fileSize: 2048,
+        description: 'Second report',
+        s3Bucket: 'bucket',
+        s3Key: 'key-2',
+        status: 'uploaded',
+        checksum: 'def',
+        metadata: JSON.stringify({ category: 'finance' }),
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]
+
+    const mockDb: MockDb = {
+      select: (args?: unknown) => {
+        if (args && typeof args === 'object' && args !== null && 'count' in (args as Record<string, unknown>)) {
+          return {
+            from: () => ({
+              where: () => Promise.resolve([{ count: records.length }]),
+            }),
+          }
+        }
+
+        return {
+          from: () => ({
+            where: () => ({
+              orderBy: () => ({
+                limit: () => ({
+                  offset: async () => records,
+                }),
+              }),
+            }),
+          }),
+        }
+      },
+    }
+
+    const app = createApp({
+      user: superAdminUser,
+      db: mockDb,
+      documentProcessor: {
+        upload: async () => {
+          throw new Error('upload should not be called')
+        },
+      },
+    })
+
+    const response = await app.request(
+      'http://localhost/?page=1&limit=10&schoolId=school-001&search=Report'
+    )
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+
+    expect(payload.documents).toHaveLength(2)
+    expect(payload.documents[0].metadata).toEqual({ category: 'reports' })
+    expect(payload.pagination).toEqual({
+      page: 1,
+      limit: 10,
+      total: 2,
+      pages: 1,
+    })
+  })
+
+  it('retrieves a document by id and enforces school ownership for non-admins', async () => {
+    const now = new Date('2024-01-02T00:00:00.000Z')
+    const record: DocumentRecord = {
+      id: 'doc-3',
+      schoolId: teacherUser.schoolId!,
+      uploaderId: teacherUser.id,
+      title: 'Syllabus',
+      fileName: 'syllabus.pdf',
+      contentType: 'application/pdf',
+      fileSize: 4096,
+      description: 'Course syllabus',
+      s3Bucket: 'bucket',
+      s3Key: 'key-3',
+      status: 'uploaded',
+      checksum: 'ghi',
+      metadata: JSON.stringify({ unit: 'algebra' }),
+      createdAt: now,
+      updatedAt: now,
+    }
+
+    const mockDb: MockDb = {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: async () => [record],
+          }),
+        }),
+      }),
+    }
+
+    const app = createApp({
+      user: teacherUser,
+      db: mockDb,
+      documentProcessor: {
+        upload: async () => {
+          throw new Error('upload should not be called')
+        },
+      },
+    })
+
+    const response = await app.request('http://localhost/doc-3')
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+
+    expect(payload.document.id).toBe('doc-3')
+    expect(payload.document.metadata).toEqual({ unit: 'algebra' })
+  })
+
+  it('uploads a document and forwards metadata and tags to the processor', async () => {
+    const uploadCalls: DocumentUploadInput[] = []
+
+    const mockProcessor = {
+      upload: async (input: DocumentUploadInput) => {
+        uploadCalls.push(input)
+        const now = new Date('2024-01-03T00:00:00.000Z')
+        const document: DocumentRecord = {
+          id: 'doc-4',
+          schoolId: teacherUser.schoolId!,
+          uploaderId: teacherUser.id,
+          title: 'Uploaded Title',
+          fileName: 'uploaded.pdf',
+          contentType: 'application/pdf',
+          fileSize: input.buffer.byteLength,
+          description: 'Uploaded description',
+          s3Bucket: 'bucket',
+          s3Key: 'key-4',
+          status: 'uploaded',
+          checksum: 'jkl',
+          metadata: JSON.stringify({ stored: true }),
+          createdAt: now,
+          updatedAt: now,
+        }
+
+        return { document, location: 'https://example.com/key-4' }
+      },
+    }
+
+    const app = createApp({
+      user: teacherUser,
+      db: { select: () => ({}) } as MockDb,
+      documentProcessor: mockProcessor,
+    })
+
+    const formData = new FormData()
+    formData.append('file', new File(['Hello World'], 'notes.txt', { type: 'text/plain' }))
+    formData.append('title', 'Lecture Notes')
+    formData.append('description', 'Classroom resources')
+    formData.append('metadata', JSON.stringify({ lesson: 'geometry', pages: 5 }))
+    formData.append('tags', JSON.stringify({ department: 'math', priority: 1 }))
+
+    const response = await app.request('http://localhost/', {
+      method: 'POST',
+      body: formData,
+    })
+
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+
+    expect(uploadCalls).toHaveLength(1)
+    const [call] = uploadCalls
+    expect(call.title).toBe('Lecture Notes')
+    expect(call.description).toBe('Classroom resources')
+    expect(call.schoolId).toBe(teacherUser.schoolId)
+    expect(call.uploaderId).toBe(teacherUser.id)
+    expect(call.metadata).toEqual({ lesson: 'geometry', pages: 5 })
+    expect(call.tags).toEqual({ department: 'math', priority: '1' })
+    expect(call.buffer.toString()).toBe('Hello World')
+
+    expect(payload.document.id).toBe('doc-4')
+    expect(payload.document.metadata).toEqual({ stored: true })
+    expect(payload.location).toBe('https://example.com/key-4')
+  })
+})

--- a/backend/src/routes/documents.ts
+++ b/backend/src/routes/documents.ts
@@ -1,0 +1,269 @@
+import { Hono } from 'hono'
+import { zValidator } from '@hono/zod-validator'
+import { z } from 'zod'
+import { and, count, desc, eq, ilike, or } from 'drizzle-orm'
+import type { SQL } from 'drizzle-orm'
+import { Buffer } from 'node:buffer'
+
+import { authMiddleware, requireSchoolAccess } from '../middleware/auth'
+import { documentProcessor } from '../lib/document-processor'
+import { db } from '../db'
+import { documents } from '../db/schema'
+
+const documentsRouter = new Hono()
+
+const listQuerySchema = z.object({
+  page: z.string().optional().default('1'),
+  limit: z.string().optional().default('20'),
+  schoolId: z.string().uuid().optional(),
+  uploaderId: z.string().uuid().optional(),
+  search: z.string().optional(),
+})
+
+type ParsedFile = {
+  arrayBuffer: () => Promise<ArrayBuffer>
+  name?: string
+  type?: string
+  size?: number
+}
+
+const parseRecord = (
+  rawValue: unknown
+): Record<string, string | number | boolean | null | undefined> | undefined => {
+  if (!rawValue) return undefined
+
+  if (typeof rawValue === 'string') {
+    const trimmed = rawValue.trim()
+    if (!trimmed) return undefined
+
+    try {
+      const parsed = JSON.parse(trimmed)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as Record<string, string | number | boolean | null | undefined>
+      }
+    } catch (error) {
+      throw new Error('Metadata payload must be valid JSON when provided')
+    }
+
+    return undefined
+  }
+
+  if (typeof rawValue === 'object' && !Array.isArray(rawValue)) {
+    return rawValue as Record<string, string | number | boolean | null | undefined>
+  }
+
+  return undefined
+}
+
+const safeParseMetadata = (metadata: string): Record<string, unknown> | null => {
+  try {
+    const parsed = JSON.parse(metadata)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>
+    }
+  } catch (_) {
+    // Ignore parsing error and return null
+  }
+
+  return null
+}
+
+documentsRouter.get(
+  '/',
+  authMiddleware,
+  requireSchoolAccess,
+  zValidator('query', listQuerySchema),
+  async (c) => {
+    try {
+      const { page, limit, schoolId, uploaderId, search } = c.req.valid('query')
+      const currentUser = c.get('user')
+
+      const pageNumber = Math.max(1, Number.parseInt(page, 10) || 1)
+      const limitNumber = Math.min(100, Math.max(1, Number.parseInt(limit, 10) || 20))
+      const offset = (pageNumber - 1) * limitNumber
+
+      const filters: SQL[] = []
+
+      let effectiveSchoolId: string | undefined
+      if (currentUser.role === 'super_admin') {
+        effectiveSchoolId = schoolId
+      } else {
+        effectiveSchoolId = currentUser.schoolId
+      }
+
+      if (!effectiveSchoolId) {
+        return c.json({ error: 'A schoolId is required to list documents' }, 400)
+      }
+
+      filters.push(eq(documents.schoolId, effectiveSchoolId))
+
+      if (uploaderId) {
+        filters.push(eq(documents.uploaderId, uploaderId))
+      }
+
+      if (search && search.trim().length) {
+        const pattern = `%${search.trim()}%`
+        const searchFilter = or(
+          ilike(documents.title, pattern),
+          ilike(documents.fileName, pattern)
+        )
+
+        if (searchFilter) {
+          filters.push(searchFilter)
+        }
+      }
+
+      const whereClause = filters.length === 1 ? filters[0] : and(...filters)
+
+      const items = await db
+        .select()
+        .from(documents)
+        .where(whereClause)
+        .orderBy(desc(documents.createdAt))
+        .limit(limitNumber)
+        .offset(offset)
+
+      const [{ count: total }] = await db
+        .select({ count: count() })
+        .from(documents)
+        .where(whereClause)
+
+      const parsedItems = items.map((item) => ({
+        ...item,
+        metadata: item.metadata ? safeParseMetadata(item.metadata) : null,
+      }))
+
+      return c.json({
+        documents: parsedItems,
+        pagination: {
+          page: pageNumber,
+          limit: limitNumber,
+          total,
+          pages: Math.ceil(total / limitNumber),
+        },
+      })
+    } catch (error) {
+      console.error('List documents error:', error)
+      return c.json({ error: 'Internal server error' }, 500)
+    }
+  }
+)
+
+documentsRouter.get('/:id', authMiddleware, requireSchoolAccess, async (c) => {
+  try {
+    const id = c.req.param('id')
+    const currentUser = c.get('user')
+
+    const documentRecords = await db
+      .select()
+      .from(documents)
+      .where(eq(documents.id, id))
+      .limit(1)
+
+    if (!documentRecords.length) {
+      return c.json({ error: 'Document not found' }, 404)
+    }
+
+    const documentRecord = documentRecords[0]
+
+    if (currentUser.role !== 'super_admin' && currentUser.schoolId !== documentRecord.schoolId) {
+      return c.json({ error: 'Access denied' }, 403)
+    }
+
+    return c.json({
+      document: {
+        ...documentRecord,
+        metadata: documentRecord.metadata ? safeParseMetadata(documentRecord.metadata) : null,
+      },
+    })
+  } catch (error) {
+    console.error('Get document error:', error)
+    return c.json({ error: 'Internal server error' }, 500)
+  }
+})
+
+documentsRouter.post('/', authMiddleware, requireSchoolAccess, async (c) => {
+  try {
+    const body = (await c.req.parseBody()) as Record<string, unknown>
+    const file = body.file as ParsedFile | undefined
+    const currentUser = c.get('user')
+
+    if (!file || typeof file.arrayBuffer !== 'function') {
+      return c.json({ error: 'A file upload is required under the "file" field' }, 400)
+    }
+
+    const arrayBuffer = await file.arrayBuffer()
+    const buffer = Buffer.from(arrayBuffer)
+
+    const originalName = typeof file.name === 'string' && file.name.length > 0 ? file.name : 'document'
+    const contentType = typeof file.type === 'string' && file.type.length > 0 ? file.type : null
+
+    const title = typeof body.title === 'string' && body.title.trim().length > 0 ? body.title.trim() : null
+    const description =
+      typeof body.description === 'string' && body.description.trim().length > 0
+        ? body.description.trim()
+        : null
+
+    const metadata = parseRecord(body.metadata)
+    const tagsRecord = parseRecord(body.tags)
+    const tags = tagsRecord
+      ? Object.fromEntries(
+          Object.entries(tagsRecord)
+            .filter(([, value]) => value !== undefined && value !== null)
+            .map(([key, value]) => [key, String(value)])
+            .filter(([, value]) => value.length > 0)
+        )
+      : undefined
+
+    let schoolId: string | undefined
+    if (currentUser.role === 'super_admin') {
+      schoolId = typeof body.schoolId === 'string' && body.schoolId.length > 0 ? body.schoolId : undefined
+    } else {
+      schoolId = currentUser.schoolId
+    }
+
+    if (!schoolId) {
+      return c.json({ error: 'A schoolId is required to upload documents' }, 400)
+    }
+
+    const uploadResult = await documentProcessor.upload({
+      buffer,
+      originalName,
+      contentType,
+      uploaderId: currentUser.id,
+      schoolId,
+      title,
+      description,
+      metadata,
+      tags,
+    })
+
+    return c.json({
+      document: {
+        ...uploadResult.document,
+        metadata: uploadResult.document.metadata
+          ? safeParseMetadata(uploadResult.document.metadata)
+          : null,
+      },
+      location: uploadResult.location,
+    })
+  } catch (error) {
+    console.error('Upload document error:', error)
+    const isClientError =
+      error instanceof Error &&
+      (error.message.toLowerCase().includes('content type') ||
+        error.message.toLowerCase().includes('document is empty') ||
+        error.message.toLowerCase().includes('maximum allowed size') ||
+        error.message.toLowerCase().includes('metadata payload') ||
+        error.message.toLowerCase().includes('schoolid is required'))
+
+    return c.json(
+      {
+        error: error instanceof Error ? error.message : 'Failed to upload document',
+      },
+      isClientError ? 400 : 500
+    )
+  }
+})
+
+export default documentsRouter


### PR DESCRIPTION
## Summary
- introduce document ingestion route that streams uploads to S3 and records metadata
- add reusable S3 client and processor utilities plus schema support for stored documents
- document required environment variables and wire the new pipeline into the API router

## Testing
- `bun run typecheck` *(fails: missing @aws-sdk packages because registry returned HTTP 403 when running bun install)*

------
https://chatgpt.com/codex/tasks/task_e_68dea1e40a7483238d07bce68587116e